### PR TITLE
memc global pointer should be thread local

### DIFF
--- a/generic/tclMemcache.c
+++ b/generic/tclMemcache.c
@@ -12,7 +12,6 @@ static inline memcached_st* get_memc()
   static __thread memcached_st *memc = NULL;
   if (memc == NULL)
   {
-    fprintf(stderr, "New memcached structure initialzed.\n");
     memc = memcached_create(NULL);
   }    
   return memc;


### PR DESCRIPTION
The global memcached_st structure *memc should be thread local to ensure thread safety.

According to the [libmemcached document](http://docs.libmemcached.org/libmemcached.html):

> memcached_st structures are thread-safe, but each thread must contain its own structure (that is, if you want to share these among threads you must provide your own locking).
